### PR TITLE
Update format for Mac address parser

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -61,7 +61,7 @@ else
 	redis.get("postImageAction", function(err,redisres)
 		{
 			if ( redisres == undefined )
-		res.send("shell");
+		res.send("reboot");
 			else
 		res.send(redisres);
 		});
@@ -75,7 +75,7 @@ app.get("/api/images", function(req,res)
 
 app.get("/api/hostname", function (req,res)
 		{
-			mac = req.param("mac").toString().toLowerCase();
+			mac = req.param("mac")
 			hostDB.getHostnameByMAC(mac, function(host)
 				{
 					if ( host )


### PR DESCRIPTION
Mac addresses are now parsed correctly to identify the hostname as
expected.

This appears necessary due to a change in the NodeJS packages.

Also changes hard-coded post-image action failover task to 'reboot' rather than shell.